### PR TITLE
Fix ar86 compiler warnings, remove alloca for host build

### DIFF
--- a/ar/Makefile
+++ b/ar/Makefile
@@ -7,7 +7,7 @@ LIBDIR	=/usr/bin
 CFLAGS	=-O2 -pipe
 LDFLAGS	=
 DEFS	=
-OBJS= ar.o alloca.o
+OBJS    = ar.o
 
 all: $(BINDIR)ar86
 

--- a/ar/Makefile.elks
+++ b/ar/Makefile.elks
@@ -7,7 +7,9 @@ LIBDIR	=/usr/bin
 CFLAGS	=-Os
 LDFLAGS	=
 DEFS	=
-OBJS= ar.o alloca.o
+OBJS    = ar.o
+# may need to replace alloca with fmemalloc for large symtabs or OWC compilation
+OBJS   += alloca.o
 
 ifeq ($(strip ${TOPDIR}),)
 	TOPDIRE=/home/rafael2k/programs/devel/elks

--- a/ar/rel_aout.h
+++ b/ar/rel_aout.h
@@ -332,7 +332,7 @@ struct relocation_info
 
 #undef N_MAGIC
 #define N_MAGIC3(magic0, magic1, type) \
-	((magic0) | ((magic1) << 8) | ((type) << 16))
+	((magic0) | ((magic1) << 8) | ((unsigned long)(type) << 16))
 #define N_MAGIC(exec) \
 	N_MAGIC3((exec).a_magic[0], (exec).a_magic[1], (exec).a_flags)
 	


### PR DESCRIPTION
Removes all compiler warnings on macOS and GCC builds. Not tested on Linux but should be without warnings.

Ar86 uses `alloca` which is dependent on the ELKS C library malloc implementation. This PR uses the host's alloca implementation for host builds, but still uses ELKS alloca for now. Also, ELKS libc has its own copy of alloca.c. Should ar86 have to be compiled in large model in order to handle larger symbol tables in .a files, alloca will likely have to be replaced with fmemalloc. An fmemfree may then have to be added somewhere.

@rafael2k, you should probably test ar86 to see how well it works for both the host and ELKS to see what the next step should be. Perhaps use the new c86lib.asm and syscall.asm to build a lib/c86.a and then use that for linking in examples/. A much larger heap size using -maout-heap= should be used so that alloca/malloc can work in small model.