### PR TITLE
Fix C99 auto declarations allowed within function blocks and for statements

### DIFF
--- a/compiler/stmt.c
+++ b/compiler/stmt.c
@@ -326,7 +326,13 @@ static STMT *forstmt P0 (void)
     getsym ();
     needpunc (tk_openpa);
     if (lang_option >= LANG_C99 && is_declaration_specifier (lastst)) {
+	init_node = NIL_EXPR;
 	lc_auto = declaration_list (sc_auto, lc_auto);
+	if (init_node != NIL_EXPR) {    /* ghaerr: initialize new for variable */
+	    snp->exp = init_node;
+	    init_node = NIL_EXPR;
+	    snp->next = NIL_STMT;
+	}
     } else {
 	snp->exp = expression ();
 #ifndef SYNTAX_CORRECT
@@ -786,8 +792,8 @@ static STMT *statement P0 (void)
 	if (init_node != NIL_EXPR) {
 	    snp = mk_stmt (st_expr);
 	    snp->exp = init_node;
-	    init_node = NIL_EXPR;
-	    snp->next = statement ();
+	    init_node = NIL_EXPR;       /* ghaerr: fixes C99 auto declarators anywhere */
+	    snp->next = NIL_STMT;
 #ifdef TRACE
 	    if (trace_option) {
 		tsnp->s1->next = snp;


### PR DESCRIPTION
Fixes auto declarations within function blocks and for statements, requires `-lang=c99`. 

Problem identified in [Known Tools Issues](https://hintron.github.io/8086-toolchain/stable/labs/tool_issues.html), discussed in https://github.com/ghaerr/elks/issues/2112#issuecomment-2507091938.

```
C86 does not support the more recent C feature of being able declare and initialize local variables 
anywhere in a function body. [FIXED - no longer a restriction]

All local variables should be declared at the beginning of their function and initialized 
separately. [FIXED - no longer a restriction]

For example, instead of

void MyFunction(void)
{
    Func1();                               /* BAD! Don't put code before variable decls. */ /* FIXED */
    int j;
    .
    .
    for(int i = 0; i < 100; i++) Func2();  /* BAD! Don't declare i here. */ /* FIXED */
    char c = 'X';                          /* BAD! Don't declare c here. */ /* FIXED */
    .
    .
}
```

> The "unexpected symbol" errors can be because c86 currently only supports declaring variables at the beginning of the function. See https://hintron.github.io/8086-toolchain/stable/labs/tool_issues.html. So I bet the make code does not respect this. It might hit some of those other limitations, too.

> I'm hoping that this is a limitation that can be fixed in the future, because most existing C code will probably need to be modified slightly to work.

@hintron, this PR will fix the above issue in your repo as well.