### PR TITLE
Correct problem with AR86 q option not working

### DIFF
--- a/libc/Makefile
+++ b/libc/Makefile
@@ -11,7 +11,7 @@ C86FLAGS="-O -warn=4 -lang=c99 -align=yes -stackopt=minimum -peep=all -stackchec
 CPPFLAGS=$(INCLUDES) $(DEFINES)
 CFLAGS=$(C86FLAGS)
 ASFLAGS=-f as86
-ARFLAGS=q
+ARFLAGS=r
 LDFLAGS=-0 -i
 
 OBJS=syscall.o c86lib.o


### PR DESCRIPTION
This fixes the problem of using ar86 q which adds another copy of the .o file instead of replacing it.

@rafael2k, I noticed that you just re-enabled the objdump86 build. This breaks `ecc`, as previously mentioned the ld86 version of objdump86 is broken, and when used in ecc to show what is happening, the script fails.

I also was going to update a working example/Makefile.elks that shows the myriad of problems we're having getting the toolchain to run on ELKS. I'll leave all this to you to fix instead.

Here is the Makefile being used which fails:
```
# FIXME cpp86 fails with the below -D in command line
#CPP=./cpp86 -D__C86__ -D__STDC__
CPP=./cpp86
CC=./c86 -O -warn=4 -lang=c99 -align=yes -stackopt=minimum -peep=all -stackcheck=no
AS=./nasm -f as86
LD=./ld86 -0 -i
AR=./ar86 rv

all: test

test: test.o
    $(LD) test.o libc86.a -o test

test.o: test.asm
    $(AS) test.asm -o test.o

test.asm: test.i
    $(CC) test.i test.asm

test.i: test.c
    $(CPP) test.c -o test.i

libc86.a: syscall.o c86lib.o
    rm -f libc86.a
    $(AR) libc86.a syscall.o c86lib.o

syscall.o: syscall.asm
    $(AS) syscall.asm

c86lib.o: c86lib.asm
    $(AS) c86lib.asm

clean:
    rm -f *.o *.a *.i test.asm
```
Here is the test.c file:
```
extern int write(int,char *,int);
extern int exit(int);

int main()
{
    write(1, "Hello World\n", 12);
    exit(0);
}
```

Thank you!