### PR TITLE
Enhance ld86 to produce v1 a.out executables for ELKS

### DIFF
--- a/ld/globvar.h
+++ b/ld/globvar.h
@@ -22,4 +22,5 @@ extern int  cpm86;			/* Generate CP/M-86 CMD header */
 
 extern bin_off_t text_base_value;	/* Base address of text seg */
 extern bin_off_t data_base_value;	/* Base or alignment of data seg */
-extern bin_off_t heap_top_value;	/* Minimum 'total' value in x86 header */
+extern bin_off_t heap_top_value;	/* Heap size */
+extern bin_off_t stack_value;	        /* Minimum stack size */

--- a/ld/ld.c
+++ b/ld/ld.c
@@ -18,6 +18,7 @@
 PUBLIC bin_off_t text_base_value = 0;	/* XXX */
 PUBLIC bin_off_t data_base_value = 0;	/* XXX */
 PUBLIC bin_off_t heap_top_value  = 0;	/* XXX */
+PUBLIC bin_off_t stack_value  = 0;	/* XXX */
 PUBLIC int headerless = 0;
 #ifndef VERY_SMALL_MEMORY
 PUBLIC int v7 = 0;
@@ -182,7 +183,7 @@ char **argv;
 		if (errno != 0)
 		    use_error("invalid data address");
 		break;
-	    case 'H':		/* heap top address */
+	    case 'H':		/* heap size */
 		if (arg[2] == 0 && ++argn >= argc)
 		    usage();
 		errno = 0;    
@@ -191,7 +192,18 @@ char **argv;
 		else
 		   heap_top_value = strtoul(arg+2, (char **)0, 16);
 		if (errno != 0)
-		    use_error("invalid heap top");
+		    use_error("invalid heap size");
+		break;
+	    case 'S':		/* min stack size */
+		if (arg[2] == 0 && ++argn >= argc)
+		    usage();
+		errno = 0;
+		if (arg[2] == 0 )
+		   stack_value = strtoul(argv[argn], (char **)0, 16);
+		else
+		   stack_value = strtoul(arg+2, (char **)0, 16);
+		if (errno != 0)
+		    use_error("invalid stack size");
 		break;
 	    case 'l':		/* library name */
 		tfn = buildname(libprefix, arg + 2, libsuffix);

--- a/ld/ld86.1
+++ b/ld/ld86.1
@@ -13,6 +13,7 @@ ld86 \- Linker for as86(1)
 .RB [ -Olibfile ]
 .RB [ -Ttextaddr ]
 .RB [ -Hheapsize ]
+.RB [ -Sstacksize ]
 .RB [ -Ddataaddr ]
 .B infile...
 
@@ -52,7 +53,10 @@ add file libdir-from-search/crtx.o to list of files linked
 data base address follows (in format suitable for strtoul)
 .TP
 .B -H
-the top of heap (initial stack) address (in format suitable for strtoul)
+the heap size in format suitable for strtoul (default 4096)
+.TP
+.B -S
+the minimum stack size in format suitable for strtoul (default 4096)
 .TP
 .B -Lx
 add dir name x to the head of the list of library dirs searched

--- a/ld/rel_aout.h
+++ b/ld/rel_aout.h
@@ -7,12 +7,13 @@ struct	exec {			/* a.out header */
   unsigned char	a_cpu;		/* cpu id */
   unsigned char	a_hdrlen;	/* length of header */
   unsigned char	a_unused;	/* reserved for future use */
-  unsigned short a_version;	/* version stamp (not used at present) */
+  unsigned short a_version;	/* version number */
   long		a_text;		/* size of text segement in bytes */
   long		a_data;		/* size of data segment in bytes */
   long		a_bss;		/* size of bss segment in bytes */
   long		a_entry;	/* entry point */
-  long		a_total;	/* total memory allocated */
+  unsigned short a_total;	/* total memory allocated */
+  unsigned short a_minstack;	/* minimum stack size */
   long		a_syms;		/* size of symbol table */
 				/* SHORT FORM ENDS HERE */
 

--- a/ld/writex86.c
+++ b/ld/writex86.c
@@ -336,8 +336,8 @@ bool_pt argxsym;
             fatalerror("data segment too large for 16bit");
     }
 
-    if( heap_top_value < 0x100 || endoffset > heap_top_value-0x100)
-       heap_top_value = endoffset + 0x8000;
+    //if( heap_top_value < 0x100 || endoffset > heap_top_value-0x100)
+       //heap_top_value = endoffset + 0x8000;
     if( heap_top_value > 0x10000 && !bits32 ) heap_top_value = 0x10000;
     setsym("__heap_top", (bin_off_t)heap_top_value);
 
@@ -678,8 +678,12 @@ PRIVATE void writeheader()
 	offtocn((char *) &header.a_entry, page_size(),
 		sizeof header.a_entry);
 
+    offtocn((char *) &header.a_version, (bin_off_t) 1,
+	    sizeof header.a_version);
     offtocn((char *) &header.a_total, (bin_off_t) heap_top_value,
 	    sizeof header.a_total);
+    offtocn((char *) &header.a_minstack, (bin_off_t) stack_value,
+	    sizeof header.a_minstack);
     if( FILEHEADERLENGTH )
        writeout((char *) &header, FILEHEADERLENGTH);
 }

--- a/ld/x86_aout.h
+++ b/ld/x86_aout.h
@@ -37,7 +37,8 @@ struct	exec {			/* a.out header */
   Long		a_data;		/* size of data segment in bytes */
   Long		a_bss;		/* size of bss segment in bytes */
   Long		a_entry;	/* entry point */
-  Long		a_total;	/* total memory allocated */
+  unsigned short a_total;	/* total memory allocated */
+  unsigned short a_minstack;	/* minimum stack size */
   Long		a_syms;		/* size of symbol table */
 
   /* SHORT FORM ENDS HERE */


### PR DESCRIPTION
ld86 now produces v1 format a.out executables. The new -S<stacksize> option and original -H<heapsize> options can be passed to set default heap and stack sizes. If not specified, 4K is used for heap and 4K for stack. 

The previous version allocated a 32K heap for all executables, so this change may require adding -H0x8000 (for 32K) heap to get old behavior. For programs where the max heap is wanted, use -H0xFFFF.

The v1 a.out format was tested on ELKS using `chmem` to display stack and heap sizes, along with v1 a.out format. The C86 toolchain itself has not been tested on ELKS with regards to the default heap changing from 32K to 4K, but will probably require changes. For best results (other than in `make`, which runs concurrently, I would suggest using max heap -H0xffff for max memory usage.

This change will also allow executables to be run on [blink16](https://github.com/ghaerr/blink16).