### PR TITLE
Fix NASM handling of non-initialized (common) data in BSS section

### DIFF
--- a/assembler/labels.c
+++ b/assembler/labels.c
@@ -349,7 +349,7 @@ void declare_as_global (char *label, char *special, efunc error)
       case GLOBAL_SYMBOL:
         break;
       case LOCAL_SYMBOL:
-        if (!lptr->defn.is_global & EXTERN_BIT)
+        if (!(lptr->defn.is_global & EXTERN_BIT))
             error(ERR_NONFATAL, "symbol `%s': GLOBAL directive must"
                   " appear before symbol definition", label);
         break;

--- a/assembler/outas86.c
+++ b/assembler/outas86.c
@@ -5,6 +5,8 @@
  * Julian Hall. All rights reserved. The software is
  * redistributable under the licence given in the file "Licence"
  * distributed in the NASM archive.
+ *
+ * 29 Nov 2024 Greg Haerr - Fixed bss section output
  */
 
 #include <stdio.h>
@@ -395,7 +397,7 @@ static void as86_write(void)
     fwritelong (0x000186A3L, as86fp);
     fputc (0x2A, as86fp);
     fwritelong (27+symlen+seglen+strslen, as86fp);   /* header length */
-    fwritelong (stext.len+sdata.len, as86fp);
+    fwritelong (stext.len+sdata.len+bsslen, as86fp);
     fwriteshort (strslen, as86fp);
     fwriteshort (0, as86fp);	       /* class = revision = 0 */
     fwritelong (0x55555555L, as86fp);   /* segment max sizes: always this */
@@ -405,9 +407,9 @@ static void as86_write(void)
     else
 	fwriteshort (stext.len, as86fp);
     if (segsize & 0x40000000L)
-	fwritelong (sdata.len, as86fp);
+	fwritelong (sdata.len+bsslen, as86fp);
     else
-	fwriteshort (sdata.len, as86fp);
+	fwriteshort (sdata.len+bsslen, as86fp);
     fwriteshort (nsyms, as86fp);
 
     /*
@@ -437,6 +439,19 @@ static void as86_write(void)
     as86_reloc_size = -1;
     as86_write_section (&stext, SECT_TEXT);
     as86_write_section (&sdata, SECT_DATA);
+    /*
+     * Append the BSS section to the .data section
+     */
+    if (bsslen > 65535L) {
+        fputc(0x13, as86fp);
+        fwritelong(bsslen, as86fp);
+    } else if (bsslen > 255) {
+        fputc(0x12, as86fp);
+        fwriteshort(bsslen, as86fp);
+    } else if (bsslen) {
+        fputc(0x11, as86fp);
+        fputc(bsslen, as86fp);
+    }
     fputc (0, as86fp);		       /* termination */
 }
 

--- a/compiler/outx86_n.c
+++ b/compiler/outx86_n.c
@@ -1103,12 +1103,12 @@ PRIVATE void put_literals P0 (void)
 }
 */
 
+#if 0
 /*
  * write out the type of the symbol
  */
 static void puttype P1 (const TYP *, tp)
 {
-#if 0
     if (tp == NIL_TYP) {
 	/* runtime support routine */
 	oprintf ("function");	// Was far
@@ -1149,8 +1149,8 @@ static void puttype P1 (const TYP *, tp)
 	oprintf ("object");     // Was byte
 	break;
     }
-#endif
 }
+#endif
 
 /* put the definition of an external name in the ouput file */
 /* assembler can find out about externals itself. This also has the

--- a/compiler/symbol.c
+++ b/compiler/symbol.c
@@ -549,8 +549,8 @@ void endblock P0 (void)
 		    check_complete (tp);
 #endif /* SYNTAX_CORRECT */
 #ifdef CPU_DEFINED
-		    put_storage (sp);	/* tentative definition */
 		    put_reference (sp);
+		    put_storage (sp);	/* tentative definition */
 #endif /* CPU_DEFINED */
 		}
 	    }

--- a/compiler/version.h
+++ b/compiler/version.h
@@ -1,9 +1,7 @@
 #ifndef _VERSION_H
 #define	_VERSION_H
 
-//#define VERSION		"5.1 (beta)"
-//#define LAST_CHANGE_DATE	"6 Sep 2002"
-#define VERSION			"5.2pre"
-#define LAST_CHANGE_DATE	"21 Nov 2024"
+#define VERSION                 "6.0pre"        /* originally 5.1 (beta) */
+#define LAST_CHANGE_DATE        "29 Nov 2024"   /* originally 6 Sep 2002 */
 
 #endif /* _VERSION_H */


### PR DESCRIPTION
Fixes #11.

Adds proper BSS section output handling after inspecting source code from most recent NASM v2.16.03.
Fixes NASM improperly handling global symbol declarations checking, which requires a global directive prior to (not after) symbol declaration in order to process symbol table output properly.
Changes C86 to produce global directive prior to symbol definition.

The combination of all the above fixes the problem described in #11 where C variables all had to be initialized in order to work. This restriction is now lifted, and space for uninitialized variables (also known as common data) is now properly allocated in object files and executables. It remains to be seen how well LD86 will handle combining common data, but this is a big step forward for the toolchain.

Updates the C86 compiler version to v6.0pre 29 Nov 2024.