### PR TITLE
Fix linker entry point and zero length data calculations

### DIFF
--- a/ld/config.h
+++ b/ld/config.h
@@ -33,3 +33,6 @@
 
 #define CREAT_PERMS	0666	/* permissions for creat() */
 #define EXEC_PERMS	0111	/* extra permissions to set for executable */
+
+/* undefine to support V7 a.out headers */
+#define VERY_SMALL_MEMORY

--- a/ld/objdump86.c
+++ b/ld/objdump86.c
@@ -830,8 +830,7 @@ static char * byteord[] = { "LITTLE_ENDIAN", "(2143)","(3412)","BIG_ENDIAN" };
    if( h_flgs & 0x80 ) printf(" A_TOVLY");
    printf("\n");
 
-   if( header[5] )
-      printf("a_entry  = 0x%08lx\n", header[5]);
+   printf("a_entry  = 0x%08lx\n", header[5]);
    printf("a_total  = 0x%08lx\n", header[6]);
    if( header[7] )
       printf("a_syms   = 0x%08lx\n", header[7]);


### PR DESCRIPTION
Sets a.out executable entry point; the linker was requiring either \_main or \_start, but not actually setting it. This caused execution to start at 0, usually with unexpected results.

Fixes a.out data size calculations when no .data or .bss segments exist.

Enhanced objdump86 to display entry point.

Defined 'VERY_SMALL_MEMORY' to decrease ld86 executable size, which removes support for UNIX V7 a.out headers, which aren't used anyways.