### PR TITLE
Fix memory allocation functions

### DIFF
--- a/assembler/nasmlib.c
+++ b/assembler/nasmlib.c
@@ -62,8 +62,7 @@ void *nasm_malloc (size_t size)
 		p = malloc((unsigned int)size);
 		if (!p)
 		{
-			p = fmemalloc(size);
-			nasm_malloc_error (ERR_WARNING, "Error allocating memory to the HEAP. Trying with fmemalloc().\n");
+			nasm_malloc_error (ERR_WARNING, "Error allocating memory in the HEAP.\n");
 		}
 	}
 	else
@@ -95,18 +94,11 @@ void *nasm_realloc (void *q, size_t size)
 	if (!q)
 		return nasm_malloc(size);
 
-	if (SEGMENT(q) == SEGMENT(&q) && size <= MAX_NEAR_ALLOC) /* near pointer and small re-alloc */
-	{
-		p = realloc(q, size);
-	}
-	else
-	{
-		p = nasm_malloc(size);
-		if (p)
-		{                    /* on fail, previous memory not freed */
-			memcpy(p, q, size);     /* FIXME copies too much!! */
-			nasm_free(q);
-		}
+	p = nasm_malloc(size);
+	if (p)
+	{                    /* on fail, previous memory not freed */
+		memcpy(p, q, size);     /* FIXME copies too much!! */
+		nasm_free(q);
 	}
 #else
 	p = q ? realloc(q, size) : malloc(size);

--- a/compiler/memmgt.c
+++ b/compiler/memmgt.c
@@ -34,7 +34,7 @@
 /*
  * Memory is allocated in Blocks of 1024 longs, which form a linked list
  */
-#define BLKLEN ((size_t)1024 * sizeof(long))
+#define BLKLEN ((size_t)768 * sizeof(long))
 #define NIL_BLK ( (struct blk *) 0)
 
 /********************************************************** Type Definitions */

--- a/compiler/proto.h
+++ b/compiler/proto.h
@@ -359,10 +359,13 @@ extern void size_type P_ ((TYP *));
 #undef malloc
 #undef realloc
 
-#define	free(s)			fmemfree(s)
-#define	malloc(s)		fmemalloc(s)
-#define realloc(p,s)    fmemrealloc((p),(s))
+#define	free(s)			memfree(s)
+#define	malloc(s)		memalloc(s)
+#define realloc(p,s)    memrealloc((p),(s))
 
+void __far *memalloc(unsigned long size);
+void memfree(void __far *ptr);
+void __far *memrealloc(void __far *ptr, unsigned long size);
 #endif
 
 #ifdef EPOC

--- a/cpp/mem.c
+++ b/cpp/mem.c
@@ -26,10 +26,12 @@ void __far *xalloc(unsigned long size)
 	if (size <= MAX_NEAR_ALLOC)
 	{
 		p = malloc((unsigned int)size);
-		if (p == NULL)
-			return (void __far *)p;
+		fp = (void __far *)p;
 	}
-	fp = fmemalloc(size);
+	else
+	{
+		fp = fmemalloc(size);
+	}
 	return fp;
 }
 #else


### PR DESCRIPTION
Many fixes for the memory allocation functions. The toolchain is stable when compiling both examples in "examples" folder.