### PR TITLE
Reduce memory requirements for OWC toolchain programs

### DIFF
--- a/as86/Makefile.elks
+++ b/as86/Makefile.elks
@@ -25,7 +25,7 @@ LDBASE += -Wl,option -Wl,dosseg
 LDBASE += -Wl,option -Wl,start=_start
 LDBASE += -Wl,option -Wl,nodefaultlibs
 LDBASE += -Wl,option -Wl,stack=0x1000
-LDBASE += -Wl,option -Wl,heapsize=0x6000
+LDBASE += -Wl,option -Wl,heapsize=512
 LDFLAGS = $(LDBASE)
 LDLIBS = -Wl,library -Wl,$(TOPDIR)/libc/libc.lib
 

--- a/as86/mem.c
+++ b/as86/mem.c
@@ -4,7 +4,7 @@
 #include <string.h>
 #include <stdio.h>
 
-#define MALLOC_ARENA_SIZE   65520U  /* size of initial arena fmemalloc (max 65520)*/
+#define MALLOC_ARENA_SIZE   16000U  /* size of initial arena fmemalloc (max 65520)*/
 #define MALLOC_ARENA_THRESH 1024U   /* max size to allocate from arena-managed heap */
 
 unsigned int malloc_arena_size = MALLOC_ARENA_SIZE;

--- a/assembler/Makefile.elks
+++ b/assembler/Makefile.elks
@@ -27,7 +27,7 @@ endif
 
 CC =  owcc -c -bnone -mcmodel=l -march=i86 -Os -std=c99 -Wc,-fpi87 -Wc,-zev -Wc,-zls -Wc,-x -fno-stack-check -fnostdlib -Wall -Wextra -Wc,-wcd=303 -I$(TOPDIRE)/libc/include -I$(TOPDIRE)/include -I$(TOPDIRE)/elks/include -I$(WATCOMC)/h -IH -D__UNIX__ -D__ELKS__ -DOF_ONLY -DOF_BIN -DOF_AS86 -DOF_DEFAULT=of_as86
 #CC = ia16-elf-gcc -mcmodel=small -std=c11 -melks-libc -mtune=i8086 -Wall -Os -mno-segment-relocation-stuff -fno-inline -fno-builtin-printf -Wno-implicit-int -Wno-parentheses  -I/home/rafael2k/programs/devel/elks/libc/include -I/home/rafael2k/programs/devel/elks/elks/include -D__ELKS__
-LINK = owcc -bos2 -s -Wl,option -Wl,start=_start -Wl,option -Wl,dosseg -Wl,option -Wl,nodefaultlibs -Wl,option -Wl,stack=0x1000 -Wl,option -Wl,heapsize=0x100 -Wl,library -Wl,$(TOPDIRE)/libc/libc.lib
+LINK = owcc -bos2 -s -Wl,option -Wl,start=_start -Wl,option -Wl,dosseg -Wl,option -Wl,nodefaultlibs -Wl,option -Wl,stack=0x1000 -Wl,option -Wl,heapsize=256 -Wl,library -Wl,$(TOPDIRE)/libc/libc.lib
 
 CFLAGS = -I.
 PERL = perl

--- a/assembler/mem.c
+++ b/assembler/mem.c
@@ -4,8 +4,8 @@
 #include <string.h>
 #include <stdio.h>
 
-#define MALLOC_ARENA_SIZE   32760U  /* size of initial arena fmemalloc (max 65520)*/
-#define MALLOC_ARENA_THRESH 20U   /* max size to allocate from arena-managed heap */
+#define MALLOC_ARENA_SIZE   8192U  /* size of initial arena fmemalloc (max 65520)*/
+#define MALLOC_ARENA_THRESH 64U   /* max size to allocate from arena-managed heap */
 
 unsigned int malloc_arena_size = MALLOC_ARENA_SIZE;
 unsigned int malloc_arena_thresh = MALLOC_ARENA_THRESH;

--- a/compiler/Makefile.elks
+++ b/compiler/Makefile.elks
@@ -117,7 +117,7 @@ endif
 
 CC=owcc
 CCFLAGS= -bnone -mcmodel=l -march=i86 -Os -std=c99 -Wc,-fpi87 -Wc,-zev -Wc,-zls -Wc,-x -fno-stack-check -fnostdlib -Wall -Wextra -Wc,-wcd=303 -I$(TOPDIRE)/libc/include -I$(TOPDIRE)/include -I$(TOPDIRE)/elks/include -I$(WATCOMC)/h -IH -D__ELKS__
-LINK = owcc -bos2 -s -Wl,option -Wl,start=_start -Wl,option -Wl,dosseg -Wl,option -Wl,nodefaultlibs -Wl,option -Wl,stack=0x1000 -Wl,option -Wl,heapsize=0x4000 -Wl,library -Wl,$(TOPDIRE)/libc/libc.lib
+LINK = owcc -bos2 -s -Wl,option -Wl,start=_start -Wl,option -Wl,dosseg -Wl,option -Wl,nodefaultlibs -Wl,option -Wl,stack=0x1000 -Wl,option -Wl,heapsize=512 -Wl,library -Wl,$(TOPDIRE)/libc/libc.lib
 
 #------------------------------------------------------------------------------
 CFLAGS=-c $(CCFLAGS) $(CFLGS)

--- a/compiler/mem.c
+++ b/compiler/mem.c
@@ -4,7 +4,7 @@
 #include <string.h>
 #include <stdio.h>
 
-#define MALLOC_ARENA_SIZE   32000U  /* size of initial arena fmemalloc (max 65520)*/
+#define MALLOC_ARENA_SIZE   16000U  /* size of initial arena fmemalloc (max 65520)*/
 #define MALLOC_ARENA_THRESH 1024U   /* max size to allocate from arena-managed heap */
 
 unsigned int malloc_arena_size = MALLOC_ARENA_SIZE;

--- a/cpp/Makefile.elks
+++ b/cpp/Makefile.elks
@@ -25,7 +25,7 @@ LDBASE += -Wl,option -Wl,dosseg
 LDBASE += -Wl,option -Wl,start=_start
 LDBASE += -Wl,option -Wl,nodefaultlibs
 LDBASE += -Wl,option -Wl,stack=0x1000
-LDBASE += -Wl,option -Wl,heapsize=0x4000
+LDBASE += -Wl,option -Wl,heapsize=512
 LDFLAGS = $(LDBASE)
 LDLIBS = -Wl,library -Wl,$(TOPDIR)/libc/libc.lib
 

--- a/cpp/mem.c
+++ b/cpp/mem.c
@@ -4,7 +4,7 @@
 #include <string.h>
 #include <stdio.h>
 
-#define MALLOC_ARENA_SIZE   65520U  /* size of initial arena fmemalloc (max 65520)*/
+#define MALLOC_ARENA_SIZE   16000U  /* size of initial arena fmemalloc (max 65520)*/
 #define MALLOC_ARENA_THRESH 1024U   /* max size to allocate from arena-managed heap */
 
 unsigned int malloc_arena_size = MALLOC_ARENA_SIZE;


### PR DESCRIPTION
These changes are the result of reviewing the debug malloc output from https://github.com/ghaerr/elks/pull/2144.

Basically, most tools are set using 16000/1024 arena heap/threshold and 512 byte default data segment heap, except the big pig NASM86, which requires 8192/64 and 256.

We are making progress, I feel really good after seeing the debug output. NASM86 is doing thousands of memory allocations, I can't even wonder what it might be doing, but I'm sure all this extra nonsense contributes to its being so slow. It takes a second or so just to assemble the output from test.asm (hello world) on ELKS QEMU! 

Tested to build test.c using make on ELKS, but not tested building chess.c. I am fairly confident this will be enough memory for larger programs. If not, please adjust. (And also definitely try out the `sysctl debug.malloc=2` before running make).