### PR TITLE
Merge with @ghaerr 8086-toolchain (#26)

### DIFF
--- a/as/assemble.c
+++ b/as/assemble.c
@@ -78,6 +78,7 @@ PRIVATE pfv rout_table[] =
     menter,
     mEwGw,
     mExGx,
+#ifdef I8087
     mf_inher,
     mf_m,
     mf_m2,
@@ -96,6 +97,7 @@ PRIVATE pfv rout_table[] =
     mf_w_m,
     mf_w_m2,
     mf_w_m2_ax,
+#endif /* I8087 */
     mgroup1,
     mgroup2,
     mgroup6,

--- a/as/const.h
+++ b/as/const.h
@@ -12,6 +12,7 @@
 
 #define I80386			/* generate 80386 code */
 #define I8086			/* but only recognize 8086 instructions */
+#undef  I8087			/* assemble floating point instrutions */
 #undef  MNSIZE			/* allow byte size in mnemonic, e.g. "movb" */
 
 #undef MC6809			/* generate 6809 code */

--- a/as/mops.c
+++ b/as/mops.c
@@ -393,14 +393,16 @@ FORWARD void Gw P((struct ea_s *eap));
 FORWARD void Gv P((struct ea_s *eap));
 FORWARD void Gx P((struct ea_s *eap));
 FORWARD void buildea P((struct ea_s *eap));
+#ifdef I8087
 FORWARD void buildfloat P((void));
 FORWARD void buildfreg P((void));
+FORWARD reg_pt fpregchk P((void));
+#endif
 FORWARD void buildimm P((struct ea_s *eap, bool_pt signflag));
 FORWARD void buildregular P((void));
 FORWARD void buildsegword P((struct ea_s *eap));
 FORWARD void buildunary P((opcode_pt opc));
 FORWARD opsize_pt displsize P((struct ea_s *eap));
-FORWARD reg_pt fpregchk P((void));
 FORWARD bool_pt getaccumreg P((struct ea_s *eap));
 FORWARD void getbinary P((void));
 FORWARD bool_pt getdxreg P((struct ea_s *eap));
@@ -567,6 +569,7 @@ register struct ea_s *eap;
     }
 }
 
+#ifdef I8087
 PRIVATE void buildfloat()
 {
     if (mcount != 0x0)
@@ -585,6 +588,7 @@ PRIVATE void buildfreg()
     postb = REG_MOD | ((opcode & 0x07) << REG_SHIFT) | (target.base - ST0REG);
     opcode = ESCAPE_OPCODE_BASE | ((opcode & 0x70) >> 0x4);
 }
+#endif /* I8087 */
 
 PRIVATE void buildimm(eap, signflag)
 register struct ea_s *eap;
@@ -680,6 +684,7 @@ register struct ea_s *eap;
     return asize;
 }
 
+#ifdef I8087
 PRIVATE reg_pt fpregchk()
 {
     reg_pt fpreg;
@@ -707,6 +712,7 @@ PRIVATE reg_pt fpregchk()
     }
     return fpreg;
 }
+#endif /* I8087 */
 
 PRIVATE bool_pt getaccumreg(eap)
 register struct ea_s *eap;
@@ -1336,6 +1342,7 @@ PUBLIC void mExGx()
     buildregular();
 }
 
+#ifdef I8087
 PUBLIC void mf_inher()
 {
     mcount += 0x2;
@@ -1611,6 +1618,7 @@ PUBLIC void mf_w_m2_ax()
     sprefix = WAIT_OPCODE;
     mf_m2_ax();
 }
+#endif /* I8087 */
 
 /* ADC, ADD, AND, CMP, OR, SBB, SUB, XOR */
 

--- a/as/opcode.h
+++ b/as/opcode.h
@@ -68,6 +68,7 @@ enum
     ENTER,
     EwGw,
     ExGx,
+#ifdef I8087
     F_INHER,
     F_M,
     F_M2,
@@ -86,6 +87,7 @@ enum
     F_W_M,
     F_W_M2,
     F_W_M2_AX,
+#endif /* I8087 */
     GROUP1,
     GROUP2,
     GROUP6,


### PR DESCRIPTION
* Reduce size of as86 by omitting float instructions if not configured

* Rename FLOAT to I8087

---------